### PR TITLE
Add default port for AMQP

### DIFF
--- a/source/url.d
+++ b/source/url.d
@@ -44,6 +44,7 @@ static this() {
 		"aaa": 3868,
 		"aaas": 5658,
 		"acap": 674,
+		"amqp": 5672,
 		"cap": 1026,
 		"coap": 5683,
 		"coaps": 5684,


### PR DESCRIPTION
According to the spec (https://www.rabbitmq.com/uri-spec.html) the default port for AMQP protocol is 5672.

Very nice library, byt he way :wink: